### PR TITLE
サンプル詳細ページからカテゴリ検索できるようにする

### DIFF
--- a/front/components/Sample/SampleInformation.vue
+++ b/front/components/Sample/SampleInformation.vue
@@ -17,7 +17,7 @@
             {{ sample.prompts[0].gpt_model }}
           </strong>
         </v-chip>
-        <v-chip class="ml-2" color="primary">
+        <v-chip class="ml-2" color="primary" @click="emitUpdateCategoryId">
           <strong>
             {{ sample.category.name }}
           </strong>
@@ -81,6 +81,9 @@ export default {
     },
     notLoginUserClick() {
       this.$emit('not-login-user-click');
+    },
+    emitUpdateCategoryId() {
+      this.$emit('sayHelloChatGPT', this.sample.category.id);
     },
   },
 };

--- a/front/pages/index.vue
+++ b/front/pages/index.vue
@@ -7,9 +7,9 @@
     <div class="sample-sorting-container mt-4">
       <SelectCategory
         class="ml-1"
-        :category-id="params.category_id"
+        :category-id="getCategoryId"
         :categories="categories"
-        @updateCategory="params.category_id = $event"
+        @updateCategory="updateCategoryId($event)"
       />
       <div class="ma-1 switch">
         新着順
@@ -37,7 +37,7 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
+import { mapGetters, mapActions } from 'vuex';
 import SelectCategory from '@/components/Category/SelectCategory.vue';
 import { handleFailure } from '@/plugins/error-handler';
 import SampleList from '@/components/Sample/SampleList.vue';
@@ -51,9 +51,6 @@ export default {
   mixins: [likeMixin, sampleListCardMixin],
   data() {
     return {
-      params: {
-        category_id: null,
-      },
       categories: [{ id: null, name: 'すべてのカテゴリ' }],
       samples: [],
       isPopularOrder: false,
@@ -61,10 +58,10 @@ export default {
     };
   },
   computed: {
-    ...mapGetters(['isLoggedIn']),
+    ...mapGetters(['isLoggedIn', 'getCategoryId']),
   },
   watch: {
-    'params.category_id': function (newCategoryId, oldCategoryId) {
+    getCategoryId: function (newCategoryId, oldCategoryId) {
       if (newCategoryId !== oldCategoryId) {
         this.getSamples(); // カテゴリIDが変更された時にサンプルを更新
       }
@@ -85,12 +82,13 @@ export default {
     }
   },
   methods: {
+    ...mapActions(['updateCategoryId']),
     async getSamples() {
       this.isLoadingSwitch = true;
       try {
         const response = await this.$axios.$get('/api/v1/samples/', {
           params: {
-            category_id: this.params.category_id,
+            category_id: this.getCategoryId,
             is_popular_order: this.isPopularOrder,
           }, // カテゴリIDをパラメータとして追加
         });

--- a/front/pages/sample/_id.vue
+++ b/front/pages/sample/_id.vue
@@ -11,6 +11,7 @@
         @find-like-id="findLikeId"
         @delete-like="deleteLike"
         @not-login-user-click="notLoginUserClick"
+        @sayHelloChatGPT="updateCategoryId"
       />
     </div>
     <v-row class="mx-4 my-6">
@@ -146,6 +147,10 @@ export default {
           handleFailure(error, this.$store);
         }
       }
+    },
+    async updateCategoryId(categoryId) {
+      await this.$store.dispatch('updateCategoryId', categoryId);
+      this.$router.push('/');
     },
   },
 };

--- a/front/pages/user/_id.vue
+++ b/front/pages/user/_id.vue
@@ -32,22 +32,12 @@ export default {
   mixins: [likeMixin, sampleListCardMixin],
   data() {
     return {
-      params: {
-        category_id: null,
-      },
       categories: [{ id: null, name: 'すべてのカテゴリ' }],
       samples: [],
     };
   },
   computed: {
     ...mapGetters(['isLoggedIn']),
-  },
-  watch: {
-    'params.category_id': function (newCategoryId, oldCategoryId) {
-      if (newCategoryId !== oldCategoryId) {
-        this.getSamples(); // カテゴリIDが変更された時にサンプルを更新
-      }
-    },
   },
   async mounted() {
     if (Number(this.$route.params.id) !== Number(this.$auth.user.id)) {

--- a/front/store/index.js
+++ b/front/store/index.js
@@ -13,12 +13,16 @@ export const state = () => ({
     color: 'error',
     timeout: 4000,
   },
+  params: {
+    category_id: null,
+  },
 });
 
 // 算出プロパティ
 export const getters = {
   isLoggedIn: (state) => !!state.user.current,
   isAdmin: (state) => (state.user.current ? !!state.user.current.admin : false),
+  getCategoryId: (state) => state.params.category_id,
 };
 // stateの値を変更する場所
 export const mutations = {
@@ -36,6 +40,9 @@ export const mutations = {
   },
   setToast(state, payload) {
     state.toast = payload;
+  },
+  setCategoryId(state, payload) {
+    state.params.category_id = payload;
   },
 };
 
@@ -59,5 +66,8 @@ export const actions = {
     color = color || 'error';
     timeout = timeout || 4000;
     commit('setToast', { msg, color, timeout });
+  },
+  updateCategoryId({ commit }, newCategoryId) {
+    commit('setCategoryId', newCategoryId);
   },
 };


### PR DESCRIPTION
## やったこと

* サンプル詳細ページでカテゴリをクリックすることでそのカテゴリに絞ったサンプル一覧ページに遷移するようにしました
* ユーザーページから余計なプロパティを削除しました。

## 動作確認

* サンプル詳細ページでカテゴリをクリックして実際に遷移することを確認
* 開発者ツールでvuexのsample_idが適切な値に変更されていることを確認

## その他

